### PR TITLE
Use v5.18 throughout the module

### DIFF
--- a/lib/AtteanX/Parser/JSONLD.pm
+++ b/lib/AtteanX/Parser/JSONLD.pm
@@ -1,4 +1,4 @@
-use v5.14;
+use v5.18;
 use warnings;
 
 =head1 NAME
@@ -40,7 +40,6 @@ This class consumes the following roles:
 =cut
 
 package AtteanX::Parser::JSONLD::Handler {
-	use v5.18;
 	use autodie;
 	use Moo;
 	use Attean::RDF;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
AtteanX-Parser-JSONLD.
We thought you might be interested in it too.

    From: Niko Tyni <ntyni@debian.org>
    Date: Thu, 15 Aug 2024 16:12:42 +0100
    X-Dgit-Generated: 0.001-4 27f2fadb36e084d6772b18ccb8d426ca2bfe7ae3
    Subject: Use v5.18 throughout the module
    
    Nested use VERSION declarations were deprecated in Perl 5.40.
    
    Bug-Debian: https://bugs.debian.org/1078073
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libatteanx-parser-jsonld-perl/raw/master/debian/patches/use-v5.18-throughout-the-module.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
